### PR TITLE
base path no longer experimental

### DIFF
--- a/src/next.js
+++ b/src/next.js
@@ -191,9 +191,7 @@ module.exports = (igniteConfig = {}) => (nextConfig = {}) => {
   return withBundleAnalyzer(
     withMdxEnhanced({
       ...nextConfig,
-      experimental: {
-        basePath: BASE_PATH,
-      },
+      basePath: BASE_PATH,
       publicRuntimeConfig: {
         assetPrefix: BASE_PATH,
       },


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.6.2-canary.22.348d4d4.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install next-ignite@0.6.2-canary.22.348d4d4.0
  # or 
  yarn add next-ignite@0.6.2-canary.22.348d4d4.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
