### PR TITLE
docs: fixed `yarn add -d`

### DIFF
--- a/docs/pages/docs/getting-started.mdx
+++ b/docs/pages/docs/getting-started.mdx
@@ -8,7 +8,7 @@ description: "A quick start guide to getting set up with next-ignite"
 ```bash
 npm i --save-dev ignite
 # or
-yarn add -d ignite
+yarn add -D ignite
 ```
 
 ## Setup


### PR DESCRIPTION
incorrect casing of `-d` (note lowsace `d`) was causing yarn to fail when copy-pasting code from docs;

ref to [yarn api](https://classic.yarnpkg.com/en/docs/cli/add#toc-yarn-add-dev-d)

## Context

In Getting Started section `yarn add` script have incorrect casing what causes yarn to fail when copy-pasting code from docs;

While very easy to fix - it could be a little annoying and can confuse newcomers.

## Demo

This is a simple docs typo fix, no demo needed (I think?..)

## Checklist

<!--
Describe everything that you did / plan to do while working on this PR.
-->
- [x] I've read [CONTRIBUTING.md](https://github.com/rsedykh/.github/blob/master/CONTRIBUTING.md)
- [x] Test everything manually
- [x] Write a good PR description
